### PR TITLE
Improve handling of "all"

### DIFF
--- a/distox.py
+++ b/distox.py
@@ -193,7 +193,7 @@ elif sys.argv[1] == 'dumpdata':
 		max_segments = 1064
 		dev_write_idx = int.from_bytes(mem_read(s, 0xe008)[0:2], 'little')
 	to_read = max_segments if sys.argv[2] == 'all' else int(sys.argv[2])
-	if int(sys.argv[2]) > max_segments:
+	if int(to_read) > max_segments:
 		raise RuntimeError(sys.argv[2] + ' is more than the maximum possible (' + str(max_segments) + ').')
 
 	progress = 0


### PR DESCRIPTION
Currently the code tries to handle "all" as a special value, but then
goes on to try to convert the string 'all' to an integer, which fails.